### PR TITLE
fix small figure on mobile

### DIFF
--- a/src/content/docs/blog/til-happy-eyeballs.mdx
+++ b/src/content/docs/blog/til-happy-eyeballs.mdx
@@ -36,8 +36,7 @@ cost of waiting for the IPv6 attempt to fail first. There's a
 <figure>
   {/* Themed SVG reads site/system theme colors via CSS vars. */}
   <RFC_8305_SVG
-    width="80%"
-    height="80%"
+    className="figure-media"
     alt="Happy Eyeballs algorithm: IPv6 starts at t0, IPv4 starts 250 ms later"
   />
   <figcaption>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -1,2 +1,14 @@
 figure { margin: 1rem 0; }
 figcaption { font-size: 0.9rem; opacity: 0.8; margin-top: 0.5rem; }
+.figure-media {
+  display: block;
+  width: 100%;
+  height: auto;
+  margin: 0;
+}
+
+@media (min-width: 768px) {
+  .figure-media {
+    width: 80%;
+  }
+}


### PR DESCRIPTION
The svg is way to small on mobile. Make it so that it use 100% on mobile/small screen and use just 80% width in a sufficiently large screen 

![image](https://github.com/user-attachments/assets/5a450f46-3741-4a1c-8f4c-04672803ca9f)

This pr fixes it. 

(Codex generated text was garbage. I rewrote the pr text) 

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972b82770f8832d85070ffdb032447e)