### PR TITLE
Fix tweet image overflow in iOS screenshot blog post

### DIFF
--- a/src/content/docs/blog/til-customized-ios-full-page-screenshot.mdx
+++ b/src/content/docs/blog/til-customized-ios-full-page-screenshot.mdx
@@ -31,7 +31,7 @@ I stumbled upon this tweet and learned that you can create a customized "screens
   >
     <Picture
       src={tweetScreenshot}
-      style="display: block; max-width: 600px; height: auto;"
+      style="display: block; width: 100%; max-width: 600px; height: auto;"
       formats={['avif', 'webp', 'jpg']}
       alt="screenshot of zats' tweet about customized iOS full page screenshot."
       quality="high"


### PR DESCRIPTION
### Motivation
- The tweet image in the iOS screenshot post could overflow the article column on narrow/mobile screens and exceed the surrounding text width.

### Description
- Update the inline image style in `src/content/docs/blog/til-customized-ios-full-page-screenshot.mdx` to include `width: 100%` while keeping `max-width: 600px` so the image scales down to the text container on small viewports.

### Testing
- Ran `npm run build` which completed successfully and produced optimized images.
- Started the dev server (`npm run dev -- --host 0.0.0.0 --port 4321`) and ran a Playwright script to capture a mobile viewport screenshot, which succeeded and produced the validation artifact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986b616e9e4832d9e754bf7aee2768b)