### PR TITLE
Fix title case for 'TIL: Semi-Linear History' post

### DIFF
--- a/src/content/docs/blog/til-semi-linear-history.mdx
+++ b/src/content/docs/blog/til-semi-linear-history.mdx
@@ -1,5 +1,5 @@
 ---
-title: "TIL: semi-linear history"
+title: "TIL: Semi-Linear History"
 description: "TIL what I have been doing for a while is called 'semi-linear history'"
 excerpt: ""
 tags:


### PR DESCRIPTION
### Motivation
- Ensure the blog post title follows the site's title-case conventions by updating the frontmatter `title` in `src/content/docs/blog/til-semi-linear-history.mdx`.

### Description
- Update the frontmatter `title` from `TIL: semi-linear history` to `TIL: Semi-Linear History` in `src/content/docs/blog/til-semi-linear-history.mdx`; no skills from `AGENTS.md` were used.

### Testing
- Ran `rg -n "semi-linear history|TIL:" .`, `git status --short`, and `git show --stat --oneline HEAD`, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a67113bd0832d9b7830b38ff66d47)